### PR TITLE
Prevent `npm install & preinstall` from running twice

### DIFF
--- a/.bluemix/pipeline.yml
+++ b/.bluemix/pipeline.yml
@@ -12,8 +12,8 @@ stages:
     build_type: npm
     script: |-
       #!/bin/bash
-      export PATH=/opt/IBM/node-v4.2/bin:$PATH
-      npm install
+      #export PATH=/opt/IBM/node-v4.2/bin:$PATH
+      #npm install
 - name: Deploy
   inputs:
   - type: job


### PR DESCRIPTION
Fixes #1
